### PR TITLE
circleci: update to latest recommended image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/golang:1.16
+      - image: cimg/go:1.16
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
This moves off what are apparently now considered "legacy" images:
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034