### PR TITLE
neural: Improved commenting/readability for MLP forward/back propagation

### DIFF
--- a/lin/lin.go
+++ b/lin/lin.go
@@ -6,7 +6,7 @@ import (
 	"math"
 )
 
-// Frame is a 2D metrix for use in linear algebra.
+// Frame is a 2D matrix for use in linear algebra.
 type Frame []Vector
 
 // DeepCopy creates a copy of the Frame with no shared memory from the
@@ -63,6 +63,53 @@ func (f Frame) Pairwise(o Frame, fn func(float32, float32) float32) Frame {
 
 // Vector is a 1D array of values for use in linear algebra computations.
 type Vector []float32
+
+// DeepCopy creates a copy of the Vector with no shared memory from the
+// original.
+func (v Vector) DeepCopy() Vector {
+	out := make(Vector, len(v))
+	copy(out, v)
+	return out
+}
+
+// Apply returns a copy of the Vector with the given function applied to each
+// element.
+func (v Vector) Apply(fn func(float32) float32) Vector {
+	out := v.DeepCopy()
+	for i := range out {
+		out[i] = fn(out[i])
+	}
+	return out
+}
+
+// Scalar creates a vector that is the result of multiplying each
+// element of this vecor with the passed in scalar value.
+func (v Vector) Scalar(s float32) Vector {
+	return v.Apply(func(e float32) float32 {
+		return e * s
+	})
+}
+
+// Subtract created a vector that is the result of subtracting the passed in
+// vector from this vector.
+func (v Vector) Subtract(o Vector) Vector {
+	out := v.DeepCopy()
+	for i := range v {
+		out[i] = v[i] - o[i]
+	}
+	return out
+}
+
+// ElementwiseProduct creates a vector that is the result of the
+// multiplication of the corresponding elements of this vector with the passed
+// in vector. Also known as the Hadamard product.
+func (v Vector) ElementwiseProduct(o Vector) Vector {
+	out := v.DeepCopy()
+	for i := range v {
+		out[i] = v[i] * o[i]
+	}
+	return out
+}
 
 // DotProduct returns the value of the dot product for two vectors.
 func DotProduct(a, b Vector) float32 {

--- a/lin/lin_test.go
+++ b/lin/lin_test.go
@@ -1,9 +1,11 @@
 package lin
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFrameDeepCopy(t *testing.T) {
@@ -73,48 +75,99 @@ func TestFramePairwise(t *testing.T) {
 	}, c)
 }
 
-func TestDotProduct(t *testing.T) {
+func TestVectorPairOperations(t *testing.T) {
 	for i, tc := range []struct {
-		a      []float32
-		b      []float32
-		answer float32
-		panics bool
+		// Inputs
+		a Vector
+		b Vector
+		// Expectations
+		dotProduct  float32
+		subtract    Vector
+		elemProduct Vector
+		panics      bool
 	}{
 		{
-			a:      []float32{0, 0},
-			b:      []float32{0, 0},
-			answer: 0,
+			a:           Vector{0, 0},
+			b:           Vector{0, 0},
+			dotProduct:  0,
+			subtract:    Vector{0, 0},
+			elemProduct: Vector{0, 0},
 		},
 		{
-			a:      []float32{0, 1},
-			b:      []float32{1, 0},
-			answer: 0,
+			a:           Vector{0, 1},
+			b:           Vector{1, 0},
+			dotProduct:  0,
+			subtract:    Vector{-1, 1},
+			elemProduct: Vector{0, 0},
 		},
 		{
-			a:      []float32{1, 1},
-			b:      []float32{1, 1},
-			answer: 2,
+			a:           Vector{1, 1},
+			b:           Vector{1, 1},
+			dotProduct:  2,
+			subtract:    Vector{0, 0},
+			elemProduct: Vector{1, 1},
 		},
 		{
-			a:      []float32{1.5, 1},
-			b:      []float32{1, 1.1},
-			answer: 2.6,
+			a:           Vector{1.5, 1},
+			b:           Vector{1, 2},
+			dotProduct:  3.5,
+			subtract:    Vector{0.5, -1},
+			elemProduct: Vector{1.5, 2},
 		},
 		{
-			a:      []float32{1},
-			b:      []float32{1, 1},
+			a:      Vector{1},
+			b:      Vector{1, 1},
 			panics: true,
 		},
 	} {
-		if tc.panics {
-			assert.Panics(t, func() {
-				_ = DotProduct(tc.a, tc.b)
-			})
-			continue
-		}
+		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
+			if tc.panics {
+				require.Panics(t, func() {
+					_ = DotProduct(tc.a, tc.b)
+				})
+				return
+			}
 
-		got := DotProduct(tc.a, tc.b)
-		assert.Equal(t, tc.answer, got, "case: %d, i", i)
+			dp := DotProduct(tc.a, tc.b)
+			assert.Equal(t, tc.dotProduct, dp, "dot product")
+
+			sb := tc.a.Subtract(tc.b)
+			assert.Equal(t, tc.subtract, sb, "subtract")
+
+			ep := tc.a.ElementwiseProduct(tc.b)
+			assert.Equal(t, tc.elemProduct, ep, "elementwise product")
+		})
+	}
+}
+
+func TestVectorScalarOperations(t *testing.T) {
+	for i, tc := range []struct {
+		// Inputs
+		a Vector
+		s float32
+		// Expectations
+		scalar Vector
+	}{
+		{
+			a:      Vector{0, 0},
+			s:      3.5,
+			scalar: Vector{0, 0},
+		},
+		{
+			a:      Vector{2, 5},
+			s:      0,
+			scalar: Vector{0, 0},
+		},
+		{
+			a:      Vector{2, 4},
+			s:      -2.5,
+			scalar: Vector{-5, -10},
+		},
+	} {
+		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
+			ep := tc.a.Scalar(tc.s)
+			assert.Equal(t, tc.scalar, ep, "scalar")
+		})
 	}
 }
 


### PR DESCRIPTION
This is motivated by a WIP blog post: https://github.com/kujenga/website/pull/19

We also expand the `lin` package to support the changes, as part of the process of making this clearer was getting rid of the outer loop on the `BackProp` function that seemed to raise the mental overhead more than was needed.